### PR TITLE
ITSASU-895: Update eligibility endpoint to retrieve pre-pop data

### DIFF
--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/AccountingMethod.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/AccountingMethod.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import play.api.libs.json._
+
+sealed trait AccountingMethod
+
+case object Cash extends AccountingMethod {
+  private[models] val CASH = "Cash"
+  override def toString : String = CASH
+}
+
+case object Accruals extends AccountingMethod {
+  private[models] val ACCRUALS = "Accruals"
+  override def toString : String = ACCRUALS
+}
+
+
+object AccountingMethod {
+
+  import Accruals.ACCRUALS
+  import Cash.CASH
+
+  val default: AccountingMethod = Cash
+
+  private val reads: Reads[AccountingMethod] = (json: JsValue) => json.validateOpt[String] map {
+    case Some("Y") => Accruals
+    case Some("N") => Cash
+    case _ => default
+  }
+
+  private val writes: Writes[AccountingMethod] = {
+    case Cash => JsString(CASH)
+    case Accruals => JsString(ACCRUALS)
+  }
+
+  implicit val format: Format[AccountingMethod] = Format[AccountingMethod](reads, writes)
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/Date.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/Date.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import scala.util.Try
+
+case class Date(day: String, month: String, year: String)
+
+object Date {
+  val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("ddMMyyyy")
+
+  def readOptionalString(maybeDateString: Option[String]): Option[Date] = maybeDateString.flatMap(dateString => {
+    Try {
+      val localDate = LocalDate.parse(dateString, formatter)
+      Date(localDate.getDayOfMonth.toString, localDate.getMonthValue.toString, localDate.getYear.toString)
+    }.toOption
+  })
+
+  implicit val format: OFormat[Date] = Json.format[Date]
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/EligibilityStatus.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/EligibilityStatus.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class EligibilityStatus(eligible: Boolean, eligibleCurrentYear: Boolean, eligibleNextYear: Boolean, prepopData: Option[PrepopData] = None)
+
+object EligibilityStatus {
+  implicit val format: OFormat[EligibilityStatus] = Json.format[EligibilityStatus]
+}
+
+case class EligibilityByYear(current: Set[String], next: Set[String])

--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/OverseasProperty.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/OverseasProperty.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+
+case class OverseasProperty(
+                             overseasPropertyStartDate: Option[Date] = None,
+                             overseasPropertyAccountingMethod: Option[AccountingMethod] = None
+                           )
+
+object OverseasProperty {
+  implicit val reads: Reads[OverseasProperty] = (
+    (JsPath \ "overseasPropertyStartDate").readNullable[String].map(Date.readOptionalString) and
+      (JsPath \ "overseasPropertyAccountingMethod").readNullable[AccountingMethod]
+    )(OverseasProperty.apply _)
+
+  implicit val writes: Writes[OverseasProperty] = Json.writes[OverseasProperty]
+
+  implicit val format: Format[OverseasProperty] = Format[OverseasProperty](reads, writes)
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/PrepopData.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/PrepopData.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+
+case class PrepopData(
+    selfEmployments: Option[Seq[SelfEmploymentData]] = None,
+    ukProperty: Option[UkProperty] = None,
+    overseasProperty: Option[OverseasProperty] = None
+)
+
+object PrepopData {
+  def filterCeasedBusinesses(maybePrepopData: Option[PrepopData]): Option[PrepopData] = {
+    maybePrepopData.map { prepopData =>
+      prepopData.copy(
+        selfEmployments = prepopData.selfEmployments.map(_.filter(_.businessCeasedDate.isEmpty))
+      )
+    }
+  }
+
+  implicit val reads: Reads[PrepopData] = (
+    (JsPath \ "selfEmployments").readNullable[Seq[SelfEmploymentData]] and
+      (JsPath).readNullable[UkProperty].map {
+        case Some(UkProperty(None, None)) => None
+        case ukProperty => ukProperty
+      } and
+      (JsPath).readNullable[OverseasProperty].map {
+        case Some(OverseasProperty(None, None)) => None
+        case overseasProperty => overseasProperty
+      }
+    )(PrepopData.apply _)
+
+  implicit val writes: Writes[PrepopData] = Json.writes[PrepopData]
+  implicit val format: Format[PrepopData] = Format[PrepopData](reads, writes)
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/SelfEmploymentData.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/SelfEmploymentData.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+
+case class SelfEmploymentData(
+                               businessName: Option[String] = None,
+                               businessTradeName: Option[String] = None,
+                               businessAddressFirstLine: Option[String] = None,
+                               businessAddressPostCode: Option[String] = None,
+                               businessStartDate: Option[Date] = None,
+                               businessAccountingMethod: Option[AccountingMethod] = None,
+                               businessCeasedDate: Option[String] = None
+                             )
+
+object SelfEmploymentData {
+  implicit val reads: Reads[SelfEmploymentData] = (
+    (JsPath \ "businessName").readNullable[String] and
+      (JsPath \ "businessTradeName").readNullable[String] and
+      (JsPath \ "businessAddressFirstLine").readNullable[String] and
+      (JsPath \ "businessAddressPostCode").readNullable[String] and
+      (JsPath \ "businessStartDate").readNullable[String].map(Date.readOptionalString) and
+      (JsPath \ "businessAccountingMethod").readNullable[AccountingMethod] and
+      (JsPath \ "businessCeasedDate").readNullable[String]
+    )(SelfEmploymentData.apply _)
+
+
+  implicit val writes: Writes[SelfEmploymentData] = Json.writes[SelfEmploymentData]
+
+  implicit val format: Format[SelfEmploymentData] = Format[SelfEmploymentData](reads, writes)
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/UkProperty.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/models/UkProperty.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+
+case class UkProperty(
+                       ukPropertyStartDate: Option[Date] = None,
+                       ukPropertyAccountingMethod: Option[AccountingMethod] = None
+                     )
+
+object UkProperty {
+  implicit val reads: Reads[UkProperty] = (
+    (JsPath \ "ukPropertyStartDate").readNullable[String].map(Date.readOptionalString) and
+      (JsPath \ "ukPropertyAccountingMethod").readNullable[AccountingMethod]
+    )(UkProperty.apply _)
+
+  implicit val writes: Writes[UkProperty] = Json.writes[UkProperty]
+
+  implicit val format: Format[UkProperty] = Format[UkProperty](reads, writes)
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptioneligibility/testonly/controllers/FeatureSwitchController.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptioneligibility/testonly/controllers/FeatureSwitchController.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json
 import play.api.mvc._
 import uk.gov.hmrc.incometaxsubscriptioneligibility.config.FeatureSwitch.switches
 import uk.gov.hmrc.incometaxsubscriptioneligibility.config.{FeatureSwitch, FeatureSwitchSetting, FeatureSwitching}
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 @Singleton
 class FeatureSwitchController @Inject()(override val controllerComponents: ControllerComponents)

--- a/it/uk/gov/hmrc/incometaxsubscriptioneligibility/helpers/externalservicemocks/AuthStub.scala
+++ b/it/uk/gov/hmrc/incometaxsubscriptioneligibility/helpers/externalservicemocks/AuthStub.scala
@@ -17,13 +17,13 @@
 package uk.gov.hmrc.incometaxsubscriptioneligibility.helpers.externalservicemocks
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import play.api.libs.json.{JsObject, Json, Writes}
+import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.incometaxsubscriptioneligibility.helpers.IntegrationTestConstants.Audit._
 
 object AuthStub extends WireMockMethods {
   val authority = "/auth/authorise"
 
-  def stubAuth[T](status: Int, body: T)(implicit writes: Writes[T]): StubMapping = {
+  def stubAuth[T](status: Int, body: T): StubMapping = {
     when(method = POST, uri = authority)
       .thenReturn(status = status, body = successfulAuthResponse(arnEnrolment))
   }

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/connectors/mocks/MockAuthConnector.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/connectors/mocks/MockAuthConnector.scala
@@ -30,7 +30,7 @@ trait MockAuthConnector extends MockFactory {
 
   def mockAuthorise[A](predicate: Predicate = EmptyPredicate, retrievals: Retrieval[A])
                       (response: Future[A])
-                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Unit =
+                      (implicit ec: ExecutionContext): Unit =
     (mockAuthConnector.authorise(_: Predicate, _: Retrieval[A])(_: HeaderCarrier, _: ExecutionContext))
       .expects(predicate, retrievals, *, ec)
       .returning(response)

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/DateSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/DateSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import org.scalatestplus.play.PlaySpec
+
+class DateSpec extends PlaySpec {
+  "Date" should {
+    "read some valid date" in {
+      Date.readOptionalString(Some("01022018")) mustBe Some(Date("1", "2", "2018"))
+    }
+
+    "read some invalid date" in {
+      Date.readOptionalString(Some("20180201")) mustBe None
+    }
+
+    "read a missing date" in {
+      Date.readOptionalString(None) mustBe None
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/OverseasPropertySpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/OverseasPropertySpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsSuccess, Json}
+
+class OverseasPropertySpec extends PlaySpec {
+  "Overseas property" should {
+    "deserialize UK property" when {
+      "the accounting method is set to 'Y'" in {
+        val actual = Json.fromJson[OverseasProperty](
+          Json.parse("""
+          {
+            "overseasPropertyStartDate" : "01012018",
+            "overseasPropertyAccountingMethod" : "Y"
+          }
+          """))
+
+        val expected = OverseasProperty(
+          overseasPropertyStartDate = Some(Date("1", "1", "2018")),
+          overseasPropertyAccountingMethod = Some(Accruals)
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the accounting method is set to 'N'" in {
+        val actual = Json.fromJson[OverseasProperty](
+          Json.parse("""
+          {
+            "overseasPropertyStartDate" : "01012018",
+            "overseasPropertyAccountingMethod" : "N"
+          }
+          """))
+
+        val expected = OverseasProperty(
+          overseasPropertyStartDate = Some(Date("1", "1", "2018")),
+          overseasPropertyAccountingMethod = Some(Cash)
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the accounting method is not provided" in {
+        val actual = Json.fromJson[OverseasProperty](
+          Json.parse("""
+          {
+            "overseasPropertyStartDate" : "01012018"
+          }
+          """))
+
+        val expected = OverseasProperty(
+          overseasPropertyStartDate = Some(Date("1", "1", "2018"))
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the start date is not provided" in {
+        val actual = Json.fromJson[OverseasProperty](
+          Json.parse("""
+          {
+            "overseasPropertyAccountingMethod" : "Y"
+          }
+          """))
+
+        val expected = OverseasProperty(
+          overseasPropertyAccountingMethod = Some(Accruals)
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the start date and the accounting method are not provided" in {
+        val actual = Json.fromJson[OverseasProperty](
+          Json.parse("""
+          {}
+          """))
+
+        val expected = OverseasProperty()
+
+        actual mustBe JsSuccess(expected)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/PrepopDataSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/PrepopDataSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsSuccess, Json}
+
+class PrepopDataSpec extends PlaySpec {
+  "Pre-pop Data" should {
+    "deserialize UK property" in {
+      val actual = Json.fromJson[PrepopData](
+        Json.parse("""
+        {
+          "ukPropertyStartDate" : "01012018",
+          "ukPropertyAccountingMethod" : "Y"
+        }
+        """))
+
+      val expected = PrepopData(
+        ukProperty = Some(UkProperty(
+          ukPropertyStartDate = Some(Date("1", "1", "2018")),
+          ukPropertyAccountingMethod = Some(Accruals)
+        ))
+      )
+
+      actual mustBe JsSuccess(expected)
+    }
+
+    "deserialize overseas property" in {
+      val actual = Json.fromJson[PrepopData](
+        Json.parse(
+          """
+        {
+          "overseasPropertyStartDate" : "01012018",
+          "overseasPropertyAccountingMethod" : "Y"
+        }
+        """))
+
+      val expected = PrepopData(
+        overseasProperty = Some(OverseasProperty(
+          overseasPropertyStartDate = Some(Date("1", "1", "2018")),
+          overseasPropertyAccountingMethod = Some(Accruals)
+        ))
+      )
+
+      actual mustBe JsSuccess(expected)
+    }
+
+    "deserialize self employments" in {
+      val actual = Json.fromJson[PrepopData](
+        Json.parse("""
+        {
+          "selfEmployments" : [
+            {
+               "businessName": "Test business name",
+               "businessTradeName": "Test business trade name",
+               "businessStartDate": "01012018",
+               "businessAccountingMethod": "Y"
+            }
+          ]
+        }
+        """))
+
+      val expected = PrepopData(
+        selfEmployments = Some(Vector(
+          SelfEmploymentData(
+            businessName = Some("Test business name"),
+            businessTradeName = Some("Test business trade name"),
+            businessStartDate = Some(Date("1", "1", "2018")),
+            businessAccountingMethod = Some(Accruals)
+          )
+        ))
+      )
+
+      actual mustBe JsSuccess(expected)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/SelfEmploymentDataSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/SelfEmploymentDataSpec.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsSuccess, Json}
+
+class SelfEmploymentDataSpec extends PlaySpec {
+  "Self employment data" should {
+    "deserialize self employment with complete information" in {
+      val actual = Json.fromJson[PrepopData](
+        Json.parse("""
+        {
+          "selfEmployments" : [
+            {
+               "businessName": "Test business name",
+               "businessTradeName": "Test business trade name",
+               "businessAddressFirstLine" : "Buckingham Palace",
+               "businessAddressPostCode": "SW1A 1AA",
+               "businessStartDate": "01012018",
+               "businessAccountingMethod": "Y",
+               "businessCeasedDate": "20180101"
+            }
+          ]
+        }
+        """))
+
+      val expected = PrepopData(
+        selfEmployments = Some(Seq(
+          SelfEmploymentData(
+            businessName = Some("Test business name"),
+            businessTradeName = Some("Test business trade name"),
+            businessAddressFirstLine = Some("Buckingham Palace"),
+            businessAddressPostCode = Some("SW1A 1AA"),
+            businessStartDate = Some(Date("1", "1", "2018")),
+            businessAccountingMethod = Some(Accruals),
+            businessCeasedDate = Some("20180101"),
+          )
+        ))
+      )
+
+      actual mustBe JsSuccess(expected)
+    }
+
+    "deserialize self employment with missing business address information" in {
+      val actual = Json.fromJson[PrepopData](
+        Json.parse("""
+        {
+          "selfEmployments" : [
+            {
+               "businessName": "Test business name",
+               "businessTradeName": "Test business trade name",
+               "businessStartDate": "01012018",
+               "businessAccountingMethod": "Y",
+               "businessCeasedDate": "20180101"
+            }
+          ]
+        }
+        """))
+
+      val expected = PrepopData(
+        selfEmployments = Some(Seq(
+          SelfEmploymentData(
+            businessName = Some("Test business name"),
+            businessTradeName = Some("Test business trade name"),
+            businessStartDate = Some(Date("1", "1", "2018")),
+            businessAccountingMethod = Some(Accruals),
+            businessCeasedDate = Some("20180101"),
+          )
+        ))
+      )
+
+      actual mustBe JsSuccess(expected)
+    }
+
+    "deserialize self employment with missing business start date" in {
+      val actual = Json.fromJson[PrepopData](
+        Json.parse("""
+        {
+          "selfEmployments" : [
+            {
+               "businessName": "Test business name",
+               "businessTradeName": "Test business trade name",
+               "businessAddressFirstLine" : "Buckingham Palace",
+               "businessAddressPostCode": "SW1A 1AA",
+               "businessAccountingMethod": "Y",
+               "businessCeasedDate": "20180101"
+            }
+          ]
+        }
+        """))
+
+      val expected = PrepopData(
+        selfEmployments = Some(Seq(
+          SelfEmploymentData(
+            businessName = Some("Test business name"),
+            businessTradeName = Some("Test business trade name"),
+            businessAddressFirstLine = Some("Buckingham Palace"),
+            businessAddressPostCode = Some("SW1A 1AA"),
+            businessAccountingMethod = Some(Accruals),
+            businessCeasedDate = Some("20180101"),
+          )
+        ))
+      )
+
+      actual mustBe JsSuccess(expected)
+    }
+
+    "deserialize self employment with missing business accounting method" in {
+      val actual = Json.fromJson[PrepopData](
+        Json.parse("""
+        {
+          "selfEmployments" : [
+            {
+               "businessName": "Test business name",
+               "businessTradeName": "Test business trade name",
+               "businessAddressFirstLine" : "Buckingham Palace",
+               "businessAddressPostCode": "SW1A 1AA",
+               "businessStartDate": "01012018",
+               "businessCeasedDate": "20180101"
+            }
+          ]
+        }
+        """))
+
+      val expected = PrepopData(
+        selfEmployments = Some(Seq(
+          SelfEmploymentData(
+            businessName = Some("Test business name"),
+            businessTradeName = Some("Test business trade name"),
+            businessAddressFirstLine = Some("Buckingham Palace"),
+            businessAddressPostCode = Some("SW1A 1AA"),
+            businessStartDate = Some(Date("1", "1", "2018")),
+            businessCeasedDate = Some("20180101"),
+          )
+        ))
+      )
+
+      actual mustBe JsSuccess(expected)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/UkPropertySpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/UkPropertySpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptioneligibility.models
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsSuccess, Json}
+
+class UkPropertySpec extends PlaySpec {
+  "Uk property" should {
+    "deserialize UK property" when {
+      "the accounting method is set to 'Y'" in {
+        val actual = Json.fromJson[UkProperty](
+          Json.parse("""
+          {
+            "ukPropertyStartDate" : "01012018",
+            "ukPropertyAccountingMethod" : "Y"
+          }
+          """))
+
+        val expected = UkProperty(
+          ukPropertyStartDate = Some(Date("1", "1", "2018")),
+          ukPropertyAccountingMethod = Some(Accruals)
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the accounting method is set to 'N'" in {
+        val actual = Json.fromJson[UkProperty](
+          Json.parse("""
+          {
+            "ukPropertyStartDate" : "01012018",
+            "ukPropertyAccountingMethod" : "N"
+          }
+          """))
+
+        val expected = UkProperty(
+          ukPropertyStartDate = Some(Date("1", "1", "2018")),
+          ukPropertyAccountingMethod = Some(Cash)
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the accounting method is not provided" in {
+        val actual = Json.fromJson[UkProperty](
+          Json.parse("""
+          {
+            "ukPropertyStartDate" : "01012018"
+          }
+          """))
+
+        val expected = UkProperty(
+          ukPropertyStartDate = Some(Date("1", "1", "2018"))
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the start date is not provided" in {
+        val actual = Json.fromJson[UkProperty](
+          Json.parse("""
+          {
+            "ukPropertyAccountingMethod" : "Y"
+          }
+          """))
+
+        val expected = UkProperty(
+          ukPropertyAccountingMethod = Some(Accruals)
+        )
+
+        actual mustBe JsSuccess(expected)
+      }
+
+      "the start date and the accounting method are not provided" in {
+        val actual = Json.fromJson[UkProperty](
+          Json.parse("""
+          {}
+          """))
+
+        val expected = UkProperty()
+
+        actual mustBe JsSuccess(expected)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/audits/EligibilityAuditModelSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/models/audits/EligibilityAuditModelSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.incometaxsubscriptioneligibility.models.audits
 
 import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.incometaxsubscriptioneligibility.models.controllist.ControlListIndices.{MARRIAGE_ALLOWANCE, NON_RESIDENT_COMPANY_LANDLORD, STUDENT_LOANS}
-import uk.gov.hmrc.incometaxsubscriptioneligibility.models.controllist.{ControlListParameter, MarriageAllowance, NonResidentCompanyLandlord, StudentLoans}
+import uk.gov.hmrc.incometaxsubscriptioneligibility.models.controllist.ControlListParameter
 
 class EligibilityAuditModelSpec extends PlaySpec {
 

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/services/mocks/MockControlListEligibilityService.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/services/mocks/MockControlListEligibilityService.scala
@@ -20,7 +20,8 @@ import org.scalamock.handlers.CallHandler6
 import org.scalamock.scalatest.MockFactory
 import play.api.mvc.Request
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.incometaxsubscriptioneligibility.services.{ControlListEligibilityService, EligibilityByYear}
+import uk.gov.hmrc.incometaxsubscriptioneligibility.models.EligibilityStatus
+import uk.gov.hmrc.incometaxsubscriptioneligibility.services.ControlListEligibilityService
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -29,13 +30,11 @@ trait MockControlListEligibilityService extends MockFactory {
   val mockControlListEligibilityService: ControlListEligibilityService = mock[ControlListEligibilityService]
 
   def mockIsEligible(sautr: String, userType: String, agentReferenceNumber: Option[String])
-                    (isEligible: Future[EligibilityByYear])
+                    (isEligible: Future[EligibilityStatus])
                     (implicit ec: ExecutionContext, request: Request[_]):
-  CallHandler6[String, String, Option[String], HeaderCarrier, ExecutionContext, Request[_], Future[EligibilityByYear]] = {
+  CallHandler6[String, String, Option[String], HeaderCarrier, ExecutionContext, Request[_], Future[EligibilityStatus]] = {
     (mockControlListEligibilityService.getEligibilityStatus(_: String, _: String, _: Option[String])(_: HeaderCarrier, _: ExecutionContext, _: Request[_]))
       .expects(sautr, userType, agentReferenceNumber, *, ec, request)
       .returning(isEligible)
   }
-
-
 }

--- a/test/uk/gov/hmrc/incometaxsubscriptioneligibility/services/mocks/MockConvertConfigValuesService.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptioneligibility/services/mocks/MockConvertConfigValuesService.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.incometaxsubscriptioneligibility.services.mocks
 
-import org.scalamock.handlers.CallHandler1
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.incometaxsubscriptioneligibility.models.TaxYear
 import uk.gov.hmrc.incometaxsubscriptioneligibility.models.controllist.ControlListParameter


### PR DESCRIPTION
- Add pre-pop data models
- Add pre-pop to eligibility endpoint response

Signed-off-by: Samir Benzenine <samir.benzenine@digital.hmrc.gov.uk>